### PR TITLE
added R.pathEq

### DIFF
--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -1510,6 +1510,15 @@ declare module R {
         intersectionWith<T>(pred: (a: T, b: T) => boolean, list1: T[], list2: T[]): T[];
 
         /**
+         * Determines whether a nested path on an object has a specific value,
+         * in `R.equals` terms. Most likely used to filter a list.
+         */
+        pathEq(path: string[], val: any, obj: any): boolean;
+        pathEq(path: string[], val: any): (obj: any) => boolean;
+        pathEq(path: string[]): (val: any, obj: any) => boolean;
+        pathEq(path: string[]): (val: any) => (obj: any) => boolean;
+
+        /**
          * Determines whether the given property of an object has a specific
          * value according to strict equality (`===`).  Most likely used to
          * filter a list.


### PR DESCRIPTION
I kept the val as `any` rather than a generic type `T` since the output (always `Boolean`) doesn't rely on the the input.