### PR TITLE
Try to improve compose()

### DIFF
--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -905,7 +905,17 @@ declare module R {
          * beginning with whatever arguments were passed to the initial invocation.
         */
         // TODO composeL
-        compose<T>(fn: T, ...fns: Function[]): T;
+        compose<T0, T1>(fn0: (x: T0) => T1): (x: T0) => T1;
+        compose<T0, T1, T2>(fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T2;
+        compose<T0, T1, T2, T3>(fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T3;
+        compose<T0, T1, T2, T3, T4>(fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T4;
+        compose<T0, T1, T2, T3, T4, T5>(fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T5;
+        compose<T0, T1, T2, T3, T4, T5, T6>(fn5: (x: T5) => T6, fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T6;
+        compose<T0, T1, T2, T3, T4, T5, T6, T7>(fn6: (x: T6) => T7, fn5: (x: T5) => T6, fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T7;
+        compose<T0, T1, T2, T3, T4, T5, T6, T7, T8>(fn7: (x: T7) => T8, fn6: (x: T6) => T7, fn5: (x: T5) => T6, fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T8;
+        compose<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(fn8: (x: T8) => T9, fn7: (x: T7) => T8, fn6: (x: T6) => T7, fn5: (x: T5) => T6, fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T9;
+        compose<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(fn9: (x: T9) => T10, fn8: (x: T8) => T9, fn7: (x: T7) => T8, fn6: (x: T6) => T7, fn5: (x: T5) => T6, fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1): (x: T0) => T10;
+        compose<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(fn9: (x: T9) => T10, fn8: (x: T8) => T9, fn7: (x: T7) => T8, fn6: (x: T6) => T7, fn5: (x: T5) => T6, fn4: (x: T4) => T5, fn3: (x: T3) => T4, fn2: (x: T2) => T3, fn1: (x: T1) => T2, fn0: (x: T0) => T1, ...fns: Function[]): (x: any) => T10;
         /*compose<T, U, V, W>(fn: (...args: T[])=> W, ...fns: ((...args: U[]) => V)[]): (...arg3: T[])=> V;*/
 
         /**


### PR DESCRIPTION
I noticed that `compose` did not work as expected. e.g.:

```javascript
const f0 = (s: string) => +s;      // string -> number
const f1 = (n: number) => n === 1; // number -> boolean
const f2 = R.compose(f1, f0);      // number -> boolean (should be: string -> boolean)
```

I tried to improve that and found a solution which works for the first 10 arguments.
If you use more than 10 arguments, the extra arguments will not be type checked and the input type of the returned function will be `any`. Also it is not possible to give more than one parameter in the first function (Valid in Ramda).

I used the following little hack to create the code:
```javascript
const createComposeDef = n => {
  const strs = [];
  for (let i = 0; i < n; i += 1) {
    const t = ['T0'];
    const f = [];
    for (let j = 0; j <= i; j += 1) {
      t.push('T' + (j + 1));
      f.push('fn' + (i-j) + ': (x: T' + (i-j) + ') => T' + (i-j+1));
    }
    strs.push('compose<' + t.join(', ') + '>(' + f.join(', ') + '): (x: T0) => T' + (i + 1) + ';');
    if (i === n - 1) {
      strs.push('compose<' + t.join(', ') + '>(' + f.join(', ') + ', ...fns: Function[]): (x: any) => T' + (i + 1) + ';');
    }
  }
  return strs.join('\n');
}
console.log(createComposeDef(10));
```