### PR TITLE
more overloads for R.split

### DIFF
--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -1448,7 +1448,13 @@ declare module R {
          * Splits a string into an array of strings based on the given
          * separator.
          */
+
+        split(sep: string): (str: string) => string[];
+        split(sep: RegExp): (str: string) => string[];
         split(sep: string, str: string): string[];
+        split(sep: RegExp, str: string): string[];
+
+
 
         // Data Analysis and Grouping Functions
         // ------------------------------------


### PR DESCRIPTION
Added different overloads for R.split. R.split works as well as with string also with regular expressions too. It may be curried so it can return a function.