### PR TITLE
Strengthened the typing of append

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -304,8 +304,8 @@ R.times(i, 5);
 () => {
     R.append('tests', ['write', 'more']); //=> ['write', 'more', 'tests']
     R.append('tests', []); //=> ['tests']
-    R.append(['tests'], ['write', 'more']); //=> ['write', 'more', ['tests']]
-    R.append(['tests'])(['write', 'more']); //=> ['write', 'more', ['tests']]
+    R.append<string, string[]>(['tests'], ['write', 'more']); //=> ['write', 'more', ['tests']]
+    R.append<string, string[]>(['tests'])(['write', 'more']); //=> ['write', 'more', ['tests']]
 }
 
 () => {

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -96,8 +96,10 @@ declare module R {
          * Returns a new list containing the contents of the given list, followed by the given element.
          */
         // note U is required (instead of just T) to allow appending an element of a different type than the array is.
-        append<T, U>(el: U, list: T[]): T[];
-        append<T, U>(el: U): (list: T[]) => T[];
+        append<T>(el: T, list: T[]): T[];
+        append<T>(el: T): (list: T[]) => T[];
+        append<T, U>(el: U, list: T[]): (T & U)[];
+        append<T, U>(el: U): (list: T[]) => (T & U)[];
 
         /**
          * `chain` maps a function over a list and concatenates the results.


### PR DESCRIPTION
`R.append` allows you to append an element of a different type to the list.  However, since we are almost certainly going to be coding with homogeneous lists most of the time I would suggest making this the default, and required the user to specify explicit generics if they want to add an element of a different type (rather than having to specify generics for the same type which is how it is at the moment).  I have also updated the return type in this case to use intersection types.