### PR TITLE
Generalized curry() to accept partial application of multiple parameters

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -50,6 +50,8 @@ class F2 {
     var x3: Function = R.curry(addFourNumbers)(1)(2)
     var x4: Function = R.curry(addFourNumbers)(1)(2)(3)
     var y1: number = R.curry(addFourNumbers)(1)(2)(3)(4)
+    var y2: number = R.curry(addFourNumbers)(1,2)(3,4)
+    var y3: number = R.curry(addFourNumbers)(1,2,3)(4)
 
     R.nAry(0, takesNoArg);
     R.nAry(0, takesOneArg);
@@ -63,6 +65,12 @@ class F2 {
     R.binary(takesTwoArgs);
     R.binary(takesThreeArgs);
 
+    var addTwoNumbers = function(a:number, b:number) { return a + b; }
+    var addTwoNumbersCurried = R.curry(addTwoNumbers);
+    
+    var inc = addTwoNumbersCurried(1);
+    var z1:number = inc(2);
+    var z2:number = addTwoNumbersCurried(2,3);
 }
 
 /* compose */
@@ -923,7 +931,7 @@ class Rectangle {
         this.width = width;
         this.height = height;
     }
-    area() {
+    area():number {
         return this.width * this.height;
     }
 };
@@ -1170,9 +1178,10 @@ class Rectangle {
  */
 () => {
     var mapIndexed = R.addIndex(R.map);
-    mapIndexed(function(val: string, idx: number) {return idx + '-' + val;}, ['f', 'o', 'o', 'b', 'a', 'r']);
-    //=> ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
-    mapIndexed((rectangle: Rectangle, idx: number) => rectangle.area()*idx, [new Rectangle(1,2), new Rectangle(4,7)]);
+    mapIndexed(function(val: string, idx: number) {return idx + '-' + val;})(['f', 'o', 'o', 'b', 'a', 'r']);
+      //=> ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
+    mapIndexed((rectangle: Rectangle, idx: number):number => rectangle.area()*idx, [new Rectangle(1,2), new Rectangle(4,7)]);
+      //=> [2, 56]
 }
 
 () => {

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -61,7 +61,44 @@ declare module R {
         <T,U>(obj: T): U;
         set<T,U>(str: string, obj: T): U;
     }
+    
+        
+    // @see https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow
+    interface CurriedFunction2<T1, T2, R> {
+        (t1: T1): (t2: T2) => R;
+        (t1: T1, t2: T2): R;
+    }
 
+    interface CurriedFunction3<T1, T2, T3, R> {
+        (t1: T1): CurriedFunction2<T2, T3, R>;
+        (t1: T1, t2: T2): (t3: T3) => R;
+        (t1: T1, t2: T2, t3: T3): R;
+    }
+    
+    interface CurriedFunction4<T1, T2, T3, T4, R> {
+        (t1: T1): CurriedFunction3<T2, T3, T4, R>;
+        (t1: T1, t2: T2): CurriedFunction2<T3, T4, R>;
+        (t1: T1, t2: T2, t3: T3): (t4: T4) => R;
+        (t1: T1, t2: T2, t3: T3, t4: T4): R;
+    }
+    
+    interface CurriedFunction5<T1, T2, T3, T4, T5, R> {
+        (t1: T1): CurriedFunction4<T2, T3, T4, T5, R>;
+        (t1: T1, t2: T2): CurriedFunction3<T3, T4, T5, R>;
+        (t1: T1, t2: T2, t3: T3): CurriedFunction2<T4, T5, R>;
+        (t1: T1, t2: T2, t3: T3, t4: T4): (t5: T5) => R;
+        (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): R;
+    }
+    
+    interface CurriedFunction6<T1, T2, T3, T4, T5, T6, R> {
+        (t1: T1): CurriedFunction5<T2, T3, T4, T5, T6, R>;
+        (t1: T1, t2: T2): CurriedFunction4<T3, T4, T5, T6, R>;
+        (t1: T1, t2: T2, t3: T3): CurriedFunction3<T4, T5, T6, R>;
+        (t1: T1, t2: T2, t3: T3, t4: T4): CurriedFunction2<T5, T6, R>;
+        (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5): (t6: T6) => R;
+        (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6): R;
+    }
+    
     interface Static {
         /*
          * List category
@@ -883,9 +920,8 @@ declare module R {
         * Creates a new list iteration function from an existing one by adding two new parameters to its callback
         * function: the current index, and the entire list.
         */
-        addIndex<T, U>(fn: (f: (item: T) => U, list: T[]) => U[]): (fn: (item: T, idx: number, list?: T[]) => U) => (list: T[]) => U[];
-        addIndex<T, U>(fn: (f: (item: T) => U, list: T[]) => U[]): (fn: (item: T, idx: number, list?: T[]) => U, list: T[]) => U[];
-
+        addIndex<T, U>(fn: (f: (item: T) => U, list: T[]) => U[])
+              : CurriedFunction2<(item: T, idx: number, list?: T[]) => U, T[], U[]>;
        /**
         * Returns a function that always returns the given value.
         */
@@ -977,11 +1013,11 @@ declare module R {
          */
         converge(after: Function, fns: Function[]): Function;
 
-        curry<T1, T2, TResult>(fn: (a: T1, b: T2) => TResult): (a: T1) => (b: T2) => TResult
-        curry<T1, T2, T3, TResult>(fn: (a: T1, b: T2, c: T3) => TResult): (a: T1) => (b: T2) => (c: T3) => TResult
-        curry<T1, T2, T3, T4, TResult>(fn: (a: T1, b: T2, c: T3, d: T4) => TResult): (a: T1) => (b: T2) => (c: T3) => (d: T4) => TResult
-        curry<T1, T2, T3, T4, T5, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5) => TResult): (a: T1) => (b: T2) => (c: T3) => (d: T4) => (e: T5) => TResult
-        curry<T1, T2, T3, T4, T5, T6, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6) => TResult): (a: T1) => (b: T2) => (c: T3) => (d: T4) => (e: T5) => (f: T6) => TResult
+        curry<T1, T2, TResult>(fn: (a: T1, b: T2) => TResult): CurriedFunction2<T1,T2, TResult>
+        curry<T1, T2, T3, TResult>(fn: (a: T1, b: T2, c: T3) => TResult): CurriedFunction3<T1,T2, T3, TResult>
+        curry<T1, T2, T3, T4, TResult>(fn: (a: T1, b: T2, c: T3, d: T4) => TResult): CurriedFunction4<T1,T2, T3, T4, TResult>
+        curry<T1, T2, T3, T4, T5, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5) => TResult): CurriedFunction5<T1,T2, T3, T4, T5, TResult>
+        curry<T1, T2, T3, T4, T5, T6, TResult>(fn: (a: T1, b: T2, c: T3, d: T4, e: T5, f: T6) => TResult): CurriedFunction6<T1,T2, T3, T4, T5, T6, TResult>
         curry(fn: Function): Function
 
         curryN(length: number, fn: (...args: any[]) => any): Function;


### PR DESCRIPTION
The existing definitions of curry() were limited to currying parameters 1 at a time

I added CurriedFunctionN interfaces, as proposed by @albrow (https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow)

Note : this may be used to simplify some definitions of curried functions in ramda.d.ts, by avoiding duplication
As an example, I just changed addIndex() prototype