### PR TITLE
Fixed partition - was only working with strings

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -636,6 +636,8 @@ interface Obj { a: number; b: number };
 () => {
     R.partition(R.contains('s'), ['sss', 'ttt', 'foo', 'bars']);
     R.partition(R.contains('s'))(['sss', 'ttt', 'foo', 'bars']);
+    R.partition(x => x > 2, [1, 2, 3, 4]);
+    R.partition(x => x > 2)([1, 2, 3, 4]);
 }
 
 () => {

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -172,7 +172,9 @@ declare module R {
          * Returns `true` if the specified item is somewhere in the list, `false` otherwise.
          * Equivalent to `indexOf(a)(list) > -1`. Uses strict (`===`) equality checking.
          */
+        contains(a: string, list: string): boolean;
         contains<T>(a: T, list: T[]): boolean;
+        contains(a: string): (list: string) => boolean;
         contains<T>(a: T): (list: T[]) => boolean;
 
         /**
@@ -392,8 +394,10 @@ declare module R {
          * Takes a predicate and a list and returns the pair of lists of elements
          * which do and do not satisfy the predicate, respectively.
          */
-        partition<T>(fn: (a: T) => boolean, list: T): T[]
-        partition<T>(fn: (a: T) => boolean): (list: T) => T[]
+        partition(fn: (a: string) => boolean, list: string[]): string[][];
+        partition<T>(fn: (a: T) => boolean, list: T[]): T[][];
+        partition<T>(fn: (a: T) => boolean): (list: T[]) => T[][];
+        partition(fn: (a: string) => boolean): (list: string[]) => string[][];
 
         /**
          * Returns a new list by plucking the same named property off all objects in the list supplied.


### PR DESCRIPTION
Hi,
This is my first typescript PR so I'm sorry if I miss something...

However, as it is now ```partition``` only works with strings, which for me (coming from Haskell) it is not even the main use case. 

Also, `contains` also allows both arguments to be strings, hence I added that too.

Let me know what you think,
Thanks