### PR TITLE
Unnest and flatten

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -809,8 +809,8 @@ type Pair = R.KeyValuePair<string, number>;
 }
 
 () => {
-    R.unnest([1, [2], [[3]]]); //=> [1, 2, [3]]
-    R.unnest([[1, 2], [3, 4], [5, 6]]); //=> [1, 2, 3, 4, 5, 6]
+    R.equals(R.unnest([1, [2], [[3]]]), [1,2,[3]]); //=> true
+    R.equals(R.unnest([[1, 2], [3, 4], [5, 6]]),[1,2,3,4,5,6]); //=> true
 }
 
 () => {

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -582,6 +582,7 @@ declare module R {
          * Returns a new list by pulling every item at the first level of nesting out, and putting
          * them in a new array.
          */
+        unnest<T>(x: T[][]): T[];
         unnest<T>(x: T[]): T[];
 
         /**
@@ -1230,6 +1231,7 @@ declare module R {
          * them in a new array, depth-first.
          */
         // checked
+        flatten(x: any[][]): any[];
         flatten(x: any[]): any[];
 
         /**

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -687,6 +687,7 @@ declare module R {
          * Creates a new object by evolving a shallow copy of object, according to the transformation functions.
          */
         evolve(transformations: {[index: string]: (value: any) => any}, obj: any): any;
+        evolve(transformations: {[index: string]: (value: any) => any}): (obj: any) => any;
 
         /**
          * Returns a list of function names of object's own functions


### PR DESCRIPTION
Ok, I am a bit more unsure about this one, but I still think it is correct:

A regular use of both unnest and flatten is to drop a dimension of an array, and hence the type signature should allow it. 

What do you think?
João