### PR TITLE
Add typings.json

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,7 @@
+{
+  "name": "ramda",
+  "main": "ramda.d.ts",
+  "author": "Erwin Poeze <erwin@mope.mobi>",
+  "description": "Type definitions for Ramda",
+  "dependencies": {}
+}


### PR DESCRIPTION
Add typings.json metadata, to make these definitions usable by the [typings](https://github.com/typings/typings) tool, used for managing type definitions.