### PR TITLE
Fix unfold's function argument return type

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -816,7 +816,7 @@ type Pair = R.KeyValuePair<string, number>;
 }
 
 () => {
-    var f = function(n: number) { return n > 50 ? false : [-n, n + 10] };
+    var f = function(n: number): [number, number]|boolean { return n > 50 ? false : [-n, n + 10] };
     R.unfold(f, 10); //=> [-10, -20, -30, -40, -50]
     R.unfold(f)(10); //=> [-10, -20, -30, -40, -50]
 }

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -569,8 +569,8 @@ declare module R {
          * to stop iteration or an array of length 2 containing the value to add to the resulting
          * list and the seed to be used in the next call to the iterator function.
          */
-        unfold<T, TResult>(fn: (seed: T) => TResult, seed: T): TResult[];
-        unfold<T, TResult>(fn: (seed: T) => TResult): (seed: T) => TResult[];
+        unfold<T, TResult>(fn: (seed: T) => [TResult, T]|boolean, seed: T): TResult[];
+        unfold<T, TResult>(fn: (seed: T) => [TResult, T]|boolean): (seed: T) => TResult[];
 
         /**
          * Returns a new list containing only one copy of each element in the original list.


### PR DESCRIPTION
The unfold function can return one of two types. Either a two-element array of with the returned array's type in the first spot, and the seed value's type in the second, or a boolean value (false). I've modified unfold's type definition to match this.

[reference](http://ramdajs.com/docs/#unfold)