### PR TITLE
fix for unfold

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -298,7 +298,9 @@ R.times(i, 5);
 });
 (() => {
     var f = function(n: number) { return n > 50 ? false : [-n, n + 10] };
-    R.unfold(f, 10); //=> [-10, -20, -30, -40, -50]
+    let a = R.unfold(f, 10); //=> [-10, -20, -30, -40, -50]
+    let b = R.unfold(f); //=> [-10, -20, -30, -40, -50]
+    let c = b(10);
 });
 /*****************************************************************
  * Function category
@@ -813,12 +815,6 @@ type Pair = R.KeyValuePair<string, number>;
     R.transduce(transducer, fn, [])(numbers); //=> [2, 3]
     R.transduce(transducer, fn)([], numbers); //=> [2, 3]
     R.transduce(transducer)(fn, [], numbers); //=> [2, 3]
-}
-
-() => {
-    var f = function(n: number): [number, number]|boolean { return n > 50 ? false : [-n, n + 10] };
-    R.unfold(f, 10); //=> [-10, -20, -30, -40, -50]
-    R.unfold(f)(10); //=> [-10, -20, -30, -40, -50]
 }
 
 () => {

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -569,8 +569,8 @@ declare module R {
          * to stop iteration or an array of length 2 containing the value to add to the resulting
          * list and the seed to be used in the next call to the iterator function.
          */
-        unfold<T, TResult>(fn: (seed: T) => [TResult, T]|boolean, seed: T): TResult[];
-        unfold<T, TResult>(fn: (seed: T) => [TResult, T]|boolean): (seed: T) => TResult[];
+        unfold<T, TResult>(fn: (seed: T) => TResult[]|boolean, seed: T): TResult[];
+        unfold<T, TResult>(fn: (seed: T) => TResult[]|boolean): (seed: T) => TResult[];
 
         /**
          * Returns a new list containing only one copy of each element in the original list.


### PR DESCRIPTION
@iofjuupasli pointed out the TS limitation to have the iterator function return a typed pair. Current proposed solution is to return a array of type TResult, next to boolean.
Returning a pair requires an interface definition that needs to be used when defining the iterator function. As the return value of the iterator function is not if big importance IMHO, I think this is the best solution.