### PR TITLE
Improve typing of toPairs and toPairsIn

### DIFF
--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -1455,7 +1455,7 @@ declare module R {
          * Note that the order of the output array is not guaranteed to be
          * consistent across different JS platforms.
          */
-        toPairs<F,S>(obj: any): [F,S][];
+        toPairs<X, V>(obj: {[k: string]: V} | {[k: number]: V}): [X, V][];
 
         /**
          * Converts an object into an array of key, value arrays.
@@ -1463,7 +1463,7 @@ declare module R {
          * Note that the order of the output array is not guaranteed to be
          * consistent across different JS platforms.
          */
-        toPairsIn<F,S>(obj: any): [F,S][];
+        toPairsIn<X, V>(obj: {[k: string]: V} | {[k: number]: V}): [X, V][];
 
 
         /**

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -1455,7 +1455,7 @@ declare module R {
          * Note that the order of the output array is not guaranteed to be
          * consistent across different JS platforms.
          */
-        toPairs<X, V>(obj: {[k: string]: V} | {[k: number]: V}): [X, V][];
+        toPairs<F,S>(obj: {[k: string]: S} | {[k: number]: S} | any): [F,S][];
 
         /**
          * Converts an object into an array of key, value arrays.
@@ -1463,7 +1463,7 @@ declare module R {
          * Note that the order of the output array is not guaranteed to be
          * consistent across different JS platforms.
          */
-        toPairsIn<X, V>(obj: {[k: string]: V} | {[k: number]: V}): [X, V][];
+        toPairsIn<F,S>(obj: {[k: string]: S} | {[k: number]: S} | any): [F,S][];
 
 
         /**


### PR DESCRIPTION
I __believe__ this is better typing for `toPairs()` and `toPairsIn()` though this is my first ever typescript definition file. (so be gentle if it's no good!)