### PR TITLE
removed placeholders, (and fixes surfacing bug in scan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,29 +34,18 @@ R.insert(2)('x')([1,2,3,4]) // => type error!
 
 In the last application of `insert` TypeScript will complain that the supplied parameters do not match the target. However, this is a valid application of the Ramda function.
 
-Another nice Ramda feature is the use of placeholders in curryed functions.
-Calling a function with placeholders creates a new (curryed) function with the
-placeholder arguments to be supplied later. It is similar to calling a curryed function with partial arguments, without to need to supply arguments from
-left to rigth. The next example of valid function applications of `R.insert`
- will clarify this:
-
-```javascript
-R.insert(R.__, 'x', [1,2,3,4])(2)
-R.insert(2, R.__, [1,2,3,4])('x')
-R.insert(R.__, 'x', R.__)(2)([1,2,3,4])
+##Note on placeholders
+Due to incompatiblity problems with typescript's typing system, Ramda's placeholder typing is removed. For binary functions the same functionaly
+can be achieved using `R.flip`. For example:
+```typescript
+// using a placeholder ...
+R.subtract(*placeholder*, 3);
+// ... is the same as
+R.flip(R.subtract)(3);
 ```
-
-TypeScript can recognize placeholders as specific types, but there are edge cases
-in with it fails to distinguish signature patterns correctly. These cases occur in
-ternary functions and function of higher order. Binary function pose no problem.
 
 ##Status
 The definitions are reorganized and updated and are more or less compatible with Ramda v0.21.0. The API of Ramda is not stable yet.
 
 This needs to be done:
-- include all functions of the latest Ramda version (currently 0.19.1)
-- reorganize functions by categories (List, Object, Function, etc)
-- find a elegant way to reflect the Ramda categories into TypeScript interface names
-  that are displayed when hovering over a function. At to moment `R.List.<function name>` is displayed, regardless of the real category a function resides.
-- Shorten function descriptions to one or two sentences to limit the size of the
-  tooltip in some IDE's.
+- include all functions of the latest Ramda version

--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -859,14 +859,11 @@ type Pair = R.KeyValuePair<string, number>;
     const a = R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
     const b = R.assoc('c')(3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
     const c = R.assoc('c', 3)({a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
-    const b1 = R.assoc(R.__, 3, {a: 1, b: 2})('c'); //=> {a: 1, b: 2, c: 3}
-    const b2 = R.assoc('c', R.__, {a: 1, b: 2})(3); //=> {a: 1, b: 2, c: 3}
 }
 
 () => {
     const a1 = R.dissoc<{a:number, c:number}>('b', {a: 1, b: 2, c: 3}); //=> {a: 1, c: 3}
     const a2 = R.dissoc('b', {a: 1, b: 2, c: 3}); //=> {a: 1, c: 3}
-    const a3 = R.dissoc<{a:number, c:number}>(R.__, {a: 1, b: 2, c: 3}); //=> {a: 1, c: 3}
     const a4 = R.dissoc('b')<{a:number, c:number}>({a: 1, b: 2, c: 3}); //=> {a: 1, c: 3}
 }
 
@@ -916,7 +913,7 @@ type Pair = R.KeyValuePair<string, number>;
     const a3: boolean = hasName({});                //=> false
 
     const point = {x: 0, y: 0};
-    const pointHas = R.has(R.__, point);
+    const pointHas = R.flip(R.has)(point);
     const b1: boolean = pointHas('x');  //=> true
     const b2: boolean = pointHas('y');  //=> true
     const b3: boolean = pointHas('z');  //=> false
@@ -936,7 +933,7 @@ class Rectangle {
     var square = new Rectangle(2, 2);
     R.hasIn('width', square);  //=> true
     R.hasIn('area', square);  //=> true
-    R.hasIn(R.__, square)('area');  //=> true
+    R.flip(R.hasIn)(square)('area');  //=> true
 }
 
 () => {
@@ -1041,7 +1038,7 @@ class Rectangle {
     R.merge({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
     //=> { 'name': 'fred', 'age': 40 }
 
-    var resetToDefault = R.merge(R.__, {x: 0});
+    var resetToDefault = R.flip(R.merge)({x: 0});
     resetToDefault({x: 5, y: 2}); //=> {x: 0, y: 2}
 }
 
@@ -1421,7 +1418,7 @@ matchPhrases(['foo', 'bar', 'baz']);
 () => {
     R.divide(71, 100); //=> 0.71
 
-    var half = R.divide(R.__, 2);
+    var half = R.flip(R.divide)(2);
     half(42); //=> 21
 
     var reciprocal = R.divide(1);
@@ -1432,7 +1429,7 @@ matchPhrases(['foo', 'bar', 'baz']);
     R.gt(2, 6); //=> false
     R.gt(2, 0); //=> true
     R.gt(2, 2); //=> false
-    R.gt(R.__, 2)(10); //=> true
+    R.flip(R.gt)(2)(10); //=> true
     R.gt(2)(10); //=> false
 }
 
@@ -1440,7 +1437,7 @@ matchPhrases(['foo', 'bar', 'baz']);
     R.gte(2, 6); //=> false
     R.gte(2, 0); //=> true
     R.gte(2, 2); //=> false
-    R.gte(R.__, 2)(10); //=> true
+    R.flip(R.gte)(2)(10); //=> true
     R.gte(2)(10); //=> false
 }
 
@@ -1455,14 +1452,14 @@ matchPhrases(['foo', 'bar', 'baz']);
     R.lt(2, 0); //=> false
     R.lt(2, 2); //=> false
     R.lt(5)(10); //=> true
-    R.lt(R.__, 5)(10); //=> false // right-sectioned currying
+    R.flip(R.lt)(5)(10); //=> false // right-sectioned currying
 }
 
 () => {
     R.lte(2, 6); //=> true
     R.lte(2, 0); //=> false
     R.lte(2, 2); //=> true
-    R.lte(R.__, 2)(1); //=> true
+    R.flip(R.lte)(2)(1); //=> true
     R.lte(2)(10); //=> true
 }
 
@@ -1474,7 +1471,7 @@ matchPhrases(['foo', 'bar', 'baz']);
     R.mathMod(17.2, 5); //=> NaN
     R.mathMod(17, 5.3); //=> NaN
 
-    var clock = R.mathMod(R.__, 12);
+    var clock = R.flip(R.mathMod)(12);
     clock(15); //=> 3
     clock(24); //=> 0
 
@@ -1489,7 +1486,7 @@ matchPhrases(['foo', 'bar', 'baz']);
     hasName({});                //=> false
 
     var point = {x: 0, y: 0};
-    var pointHas = R.has(R.__, point);
+    var pointHas = R.flip(R.has)(point);
     pointHas('x');  //=> true
     pointHas('y');  //=> true
     pointHas('z');  //=> false
@@ -1523,7 +1520,7 @@ matchPhrases(['foo', 'bar', 'baz']);
     R.modulo(-17, 3); //=> -2
     R.modulo(17, -3); //=> 2
 
-    var isOdd = R.modulo(R.__, 2);
+    var isOdd = R.flip(R.modulo)(2);
     isOdd(42); //=> 0
     isOdd(21); //=> 1
 }
@@ -1547,7 +1544,7 @@ matchPhrases(['foo', 'bar', 'baz']);
 () => {
     R.subtract(10, 8); //=> 2
 
-    var minus5 = R.subtract(R.__, 5);
+    var minus5 = R.flip(R.subtract)(5);
     minus5(17); //=> 12
 
     var complementaryAngle = R.subtract(90);

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -2,12 +2,6 @@ declare var R: R.Static;
 
 declare module R {
 
-    /**
-     * A special placeholder value used to specify "gaps" within curried functions,
-     * allowing partial application of any combination of arguments, regardless of their positions.
-     */
-    interface placeholder {}
-
     interface ListIterator<T, TResult> {
         (value: T, index: number, list: T[]): TResult;
     }
@@ -107,12 +101,6 @@ declare module R {
 
     interface Static {
 
-        /**
-         * A special placeholder value used to specify "gaps" within curried functions, allowing partial application
-         * of any combination of arguments, regardless of their positions.
-         */
-        __: placeholder;
-
        /**
         * Adds two numbers (or strings). Equivalent to a + b but curried.
         */
@@ -202,8 +190,6 @@ declare module R {
         /**
          * Makes a shallow clone of an object, setting or overriding the specified property with the given value.
          */
-        assoc<U>(prop: string, val: placeholder, obj: U): <T>(val: T) => {prop: T} & U;
-        assoc<T,U>(prop: placeholder, val: T, obj: U): (prop: string ) => {prop: T} & U;
         assoc<T,U>(prop: string, val: T, obj: U): {prop: T} & U;
         assoc(prop: string): <T,U>(val: T, obj: U) => {prop: T} & U;
         assoc<T>(prop: string, val: T): <U>(obj: U) => {prop: T} & U;
@@ -409,14 +395,12 @@ declare module R {
          */
         divide(a: number, b: number): number;
         divide(a: number): (b: number) => number;
-        divide(a: placeholder, b: number): (b: number) => number;
 
         /**
          * Returns a new object that does not contain a prop property.
          */
         // It seems impossible to infer the return type, so this may to be specified explicitely
         dissoc<T>(prop: string, obj: any): T;
-        dissoc<T>(prop: placeholder, obj: any): (prop: string) => T;
         dissoc(prop: string): <U>(obj: any) => U;
 
         /**
@@ -576,14 +560,12 @@ declare module R {
          */
         gt(a: number, b: number): boolean;
         gt(a: number): (b: number) => boolean;
-        gt(a: placeholder, b: number): (b: number) => boolean;
 
         /**
          * Returns true if the first parameter is greater than or equal to the second.
          */
         gte(a: number, b: number): boolean;
         gte(a: number): (b: number) => boolean;
-        gte(a: placeholder, b: number): (b: number) => boolean;
 
         /**
          * Splits a list into sublists stored in an object, based on the result of
@@ -598,14 +580,12 @@ declare module R {
          */
         has<T>(s: string, obj: T): boolean;
         has(s: string): <T>(obj: T) => boolean;
-        has<T>(s: placeholder, obj: T): (a: string) => boolean;
 
         /**
          * Returns whether or not an object or its prototype chain has a property with the specified name
          */
         hasIn<T>(s: string, obj: T): boolean;
         hasIn(s: string): <T>(obj: T) => boolean;
-        hasIn<T>(s: placeholder, obj: T): (a: string) => boolean;
 
         /**
          * Returns the first element in a list.
@@ -837,14 +817,12 @@ declare module R {
          */
         lt(a: number, b: number): boolean;
         lt(a: number): (b: number) => boolean;
-        lt(a: placeholder, b: number): (b: number) => boolean;
 
         /**
          * Returns true if the first parameter is less than or equal to the second.
          */
         lte(a: number, b: number): boolean;
         lte(a: number): (b: number) => boolean;
-        lte(a: placeholder, b: number): (b: number) => boolean;
 
         /**
          * Returns a new list, constructed by applying the supplied function to every element of the supplied list.
@@ -900,7 +878,6 @@ declare module R {
          */
         mathMod(a: number, b: number): number;
         mathMod(a: number): (b: number) => number;
-        mathMod(a: placeholder, b: number): (a: number) => number;
 
 
         /**
@@ -928,7 +905,6 @@ declare module R {
          * merged with the own properties of object b.
          * This function will *not* mutate passed-in objects.
          */
-        merge<T2>(a: R.placeholder, b: T2): <T1>(a: T1) => T1&T2;
         merge<T1, T2>(a: T1, b: T2): T1 & T2;
         merge<T1>(a: T1): <T2>(b: T2) => T1 & T2;
 
@@ -977,7 +953,6 @@ declare module R {
          * modulo. For mathematical modulo see `mathMod`
          */
         modulo(a: number, b: number): number;
-        modulo(a: placeholder, b: number): (a: number) => number;
         modulo(a: number): (b: number) => number;
 
         /**
@@ -985,7 +960,6 @@ declare module R {
          */
         multiply(a: number, b: number): number;
         multiply(a: number): (b: number) => number;
-        multiply(a: placeholder, b: number): (a: number) => number;
 
 
         /**
@@ -1103,7 +1077,6 @@ declare module R {
          * Retrieve the value at a given path.
          */
         path<T>(path: string[], obj: any): T;
-        path(path: placeholder, obj: any): <T>(path: string[]) => T;
         path(path: string[]): <T>(obj: any) => T;
 
         /**
@@ -1348,9 +1321,9 @@ declare module R {
         /**
          * Scan is similar to reduce, but returns a list of successively reduced values from the left.
          */
-        scan<T, TResult>(fn: (acc: TResult, elem: T) => TResult, acc: TResult, list: T[]): TResult;
-        scan<T, TResult>(fn: (acc: TResult, elem: T) => TResult): (acc: TResult, list: T[]) => TResult;
-        scan<T, TResult>(fn: (acc: TResult, elem: T) => TResult, acc: TResult): (list: T[]) => TResult;
+        scan<T, TResult>(fn: (acc: TResult, elem: T) => any, acc: TResult, list: T[]): TResult[];
+        scan<T, TResult>(fn: (acc: TResult, elem: T) => any, acc: TResult): (list: T[]) => TResult[];
+        scan<T, TResult>(fn: (acc: TResult, elem: T) => any): (acc: TResult, list: T[]) => TResult[];
 
         /**
          * Returns the result of "setting" the portion of the given data structure focused by the given lens to the
@@ -1381,7 +1354,6 @@ declare module R {
          * Sorts the list according to a key generated by the supplied function.
          */
         sortBy<T>(fn: (a: any) => string, list: T[]): T[];
-        sortBy<T>(__: placeholder, list: T[]): T[];
         sortBy(fn: (a: any) => string): <T>(list: T[]) => T[];
 
         /**
@@ -1416,7 +1388,6 @@ declare module R {
          * Subtracts two numbers. Equivalent to `a - b` but curried.
          */
         subtract(a: number, b: number): number;
-        subtract(a: placeholder, b: number): (a: number) => number;
         subtract(a: number): (b: number) => number;
 
         /**


### PR DESCRIPTION
Refering to #57.

Removes support of ramda's `placeholders` as they don't play nicely with typescript.
In the test file, `placeholders` are replaced by `flip`ing of arguments, (except for the case of ternary functions).

Please respond to this PR if you have strong objections against removing (and have a better solution ;)). If there are no serious objections, the PR will become effective within a few days.