### PR TITLE
added support for addIndex to reduce and forEach

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -705,14 +705,15 @@ interface Obj { a: number; b: number };
 }
 
 () => {
+    var reduceIndexed = R.addIndex(R.reduce);
     var letters = ['a', 'b', 'c'];
     var objectify = function(accObject: {[elem:string]: number}, elem: string, idx: number, list: string[]) {
         accObject[elem] = idx;
         return accObject;
     };
-    R.reduceIndexed(objectify, {}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
-    R.reduceIndexed(objectify)({}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
-    R.reduceIndexed(objectify, {})(letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
+    reduceIndexed(objectify, {}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
+    reduceIndexed(objectify)({}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
+    reduceIndexed(objectify, {})(letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
 }
 
 interface KeyValuePair<K, V> extends Array<K | V> { 0 : K; 1 : V; }
@@ -1252,6 +1253,18 @@ matchPhrases(['foo', 'bar', 'baz']);
     mapIndexed((rectangle: Rectangle, idx: number):number => rectangle.area()*idx, [new Rectangle(1,2), new Rectangle(4,7)]);
       //=> [2, 56]
 }
+
+() => {
+    var reduceIndexed = R.addIndex(R.reduce);
+    reduceIndexed(function(acc: string, val: string, idx: number) {
+        return acc + ',' + idx + '-' + val;
+        }
+        ,''
+        ,['f', 'o', 'o', 'b', 'a', 'r']);
+      //=> ['0-f,1-o,2-o,3-b,4-a,5-r']
+}
+
+
 
 () => {
     var t = R.always('Tee');

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -115,9 +115,14 @@ declare namespace R {
         * Creates a new list iteration function from an existing one by adding two new parameters to its callback
         * function: the current index, and the entire list.
         */
-       addIndex<T, U>(fn: (f: (item: T) => U, list: T[]) => U[])
-              : CurriedFunction2<(item: T, idx: number, list?: T[]) => U, T[], U[]>;
-
+       addIndex<T,U>(fn: (f: (item: T) => U, list: T[]) => U[] ) 
+         : CurriedFunction2<(item: T, idx: number, list?: T[]) => U, T[], U[]>;
+       /* Special case for forEach */
+       addIndex<T>(fn: (f: (item: T) => void, list: T[]) => T[]) 
+         : CurriedFunction2<(item: T, idx: number, list?: T[]) => void, T[], T[]>;
+       /* Special case for reduce */
+       addIndex<T,U>(fn: (f: (acc:U, item: T) => U, aci:U, list: T[]) => U) 
+         : CurriedFunction3<(acc:U, item: T, idx: number, list?: T[]) => U, U, T[], U>;
 
         /**
          * Applies a function to the value at the given index of an array, returning a new copy of the array with the


### PR DESCRIPTION
So, new attempt to address #62 .

I added the missing types to the new `reduce` targeted definition, and I also needed to add a `forEach` specific definition.

The tests now seem to be passing! (I also added one more test, and modified the existing one regarding reduceIndexed).

What do you think?