### PR TITLE
Fix typing for R.maxBy and R.minBy. Fixes #72

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -1701,7 +1701,8 @@ matchPhrases(['foo', 'bar', 'baz']);
 }
 
 () => {
-    let x: number = R.max(7, 3); //=> 7
+    let x: R.Ord = R.max(7, 3); //=> 7
+    let y: R.Ord = R.max('a', 'z'); //=> 'z'
 }
 
 () => {
@@ -1724,7 +1725,8 @@ matchPhrases(['foo', 'bar', 'baz']);
 }
 
 () => {
-    let x: number = R.min(9, 3); //=> 3
+    let x: R.Ord = R.min(9, 3); //=> 3
+    let y: R.Ord = R.min('a', 'z'); //=> 'a'
 }
 
 () => {

--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -1705,10 +1705,12 @@ matchPhrases(['foo', 'bar', 'baz']);
 }
 
 () => {
-    function cmp(obj: any) { return obj.x; }
-    var a = {x: 1}, b = {x: 2}, c = {x: 3};
-    R.maxBy(cmp, [a, b, c]); //=> {x: 3}
-    R.maxBy(cmp)([a, b, c]); //=> {x: 3}
+    function cmp(obj: { x: R.Ord }) { return obj.x; }
+    var a = {x: 1}, b = {x: 2}, c = {x: 3}, d = {x: "a"}, e = {x:"z"};
+    R.maxBy(cmp, a, c); //=> {x: 3}
+    R.maxBy(cmp)(a, c); //=> {x: 3}
+    R.maxBy(cmp)(a)(b);
+    R.maxBy(cmp)(d)(e);
 }
 
 () => {
@@ -1726,10 +1728,12 @@ matchPhrases(['foo', 'bar', 'baz']);
 }
 
 () => {
-    function cmp(obj: any) { return obj.x; }
-    var a = {x: 1}, b = {x: 2}, c = {x: 3};
-    R.minBy(cmp, [a, b, c]); //=> {x: 1}
-    R.minBy(cmp)([a, b, c]); //=> {x: 1}
+    function cmp(obj: {x: R.Ord}) { return obj.x; }
+    var a = {x: 1}, b = {x: 2}, c = {x: 3}, d = {x: "a"}, e = {x: "z"};
+    R.minBy(cmp, a, b); //=> {x: 1}
+    R.minBy(cmp)(a, b); //=> {x: 1}
+    R.minBy(cmp)(a)(c);
+    R.minBy(cmp, d, e);
 }
 
 () => {

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -918,8 +918,8 @@ declare namespace R {
         /**
          * Returns the larger of its two arguments.
          */
-        max(a: number, b: number): number;
-        max(a: number): (b: number) => number;
+        max(a: Ord, b: Ord): Ord;
+        max(a: Ord): (b: Ord) => Ord;
 
         /**
          * Takes a function and two values, and returns whichever value produces
@@ -983,8 +983,8 @@ declare namespace R {
         /**
          * Returns the smaller of its two arguments.
          */
-        min(a: number, b: number): number;
-        min(a: number): (b: number) => number;
+        min(a: Ord, b: Ord): Ord;
+        min(a: Ord): (b: Ord) => Ord;
 
         /**
          * Takes a function and two values, and returns whichever value produces

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -3,6 +3,7 @@
 declare var R: R.Static;
 
 declare namespace R {
+    type Ord = number | string | boolean;
 
     interface ListIterator<T, TResult> {
         (value: T, index: number, list: T[]): TResult;
@@ -921,11 +922,13 @@ declare namespace R {
         max(a: number): (b: number) => number;
 
         /**
-         * Determines the largest of a list of items as determined by pairwise comparisons from the supplied comparator.
+         * Takes a function and two values, and returns whichever value produces
+         * the larger result when passed to the provided function.
          */
-        maxBy<T>(keyFn: (a: T) => number, list: T[]): T;
-        maxBy<T>(keyFn: (a: T) => number): (list: T[]) => T;
-
+        maxBy<T>(keyFn: (a: T) => Ord, a: T, b: T): T;
+        maxBy<T>(keyFn: (a: T) => Ord, a: T): (b: T) => T;
+        maxBy<T>(keyFn: (a: T) => Ord): CurriedFunction2<T, T, T>
+        
         /**
          * Returns the mean of the given list of numbers.
          */
@@ -984,10 +987,12 @@ declare namespace R {
         min(a: number): (b: number) => number;
 
         /**
-         * Determines the smallest of a list of items as determined by pairwise comparisons from the supplied comparator.
+         * Takes a function and two values, and returns whichever value produces
+         * the smaller result when passed to the provided function.
          */
-        minBy<T>(keyFn: (a: T) => number, list: T[]): T;
-        minBy<T>(keyFn: (a: T) => number): (list: T[]) => T;
+        minBy<T>(keyFn: (a: T) => Ord, a: T, b: T): T;
+        minBy<T>(keyFn: (a: T) => Ord, a: T): (b: T) => T;
+        minBy<T>(keyFn: (a: T) => Ord): CurriedFunction2<T, T, T>
 
         /**
          * Divides the second parameter by the first and returns the remainder.


### PR DESCRIPTION
#72 seems to check out. it seems they made this change over a year ago at v0.16.

https://github.com/ramda/ramda/commit/43b57125e746f7ec9a8751e8a0a77869cbd9d962

This PR:
1. adjusts the typings for these functions to match API of ramda 0.21
2. adds an Ord type alias that mimicks Ord typeclass, and constrains `keyFn` to return something that makes sense to compare. ~~TODO might be to do the same for min and max.~~