### PR TITLE
Misc. additional fixes

### DIFF
--- a/global/ramda.d.ts
+++ b/global/ramda.d.ts
@@ -103,6 +103,8 @@ declare namespace R {
 
     interface Static {
 
+       __: any;
+
        /**
         * Adds two numbers (or strings). Equivalent to a + b but curried.
         */

--- a/global/ramda.d.ts
+++ b/global/ramda.d.ts
@@ -349,6 +349,7 @@ declare namespace R {
          * Wraps a constructor function inside a curried function that can be called with the same arguments and returns the same type.
          * The arity of the function returned is specified to allow using variadic constructor functions.
          */
+        constructN(n: number, fn: Function): (...any) => Object;
         constructN(n: number, fn: Function): Function;
 
 

--- a/global/ramda.d.ts
+++ b/global/ramda.d.ts
@@ -1225,8 +1225,8 @@ declare namespace R {
          * Returns a function that when supplied an object returns the indicated property of that object, if it exists.
          * Note: TS1.9 # replace any by dictionary
          */
-        prop<T>(p: string, obj: any): T;
-        prop<T>(p: string): <T>(obj: any) => T;
+        prop<T>(p: string | number, obj: any): T;
+        prop<T>(p: string | number): <T>(obj: any) => T;
 
         /**
          * Determines whether the given property of an object has a specific
@@ -1236,11 +1236,11 @@ declare namespace R {
         // propEq<T>(name: string, val: T, obj: {[index:string]: T}): boolean;
         // propEq<T>(name: string, val: T, obj: {[index:number]: T}): boolean;
         propEq<T>(name: string, val: T, obj: any): boolean;
-        // propEq<T>(name: number, val: T, obj: any): boolean;
+        propEq<T>(name: number, val: T, obj: any): boolean;
         propEq<T>(name: string, val: T): (obj: any) => boolean;
-        // propEq<T>(name: number, val: T): (obj: any) => boolean;
+        propEq<T>(name: number, val: T): (obj: any) => boolean;
         propEq(name: string): <T>(val: T, obj: any) => boolean;
-        // propEq(name: number): <T>(val: T, obj: any) => boolean;
+        propEq(name: number): <T>(val: T, obj: any) => boolean;
 
         /**
          * Returns true if the specified object property is of the given type; false otherwise.


### PR DESCRIPTION
Some additional fixes not addressed by #83:

 - The `__` placeholder: currently impossible to import it at all
 - `constructN`: doesn't work in multiple contexts, i.e. `map(constructN(1, Foo))`
 - `prop`/`propEq`: enabled numbers for pulling from array offsets

Let me know if this needs changes or you have any other feedback.