### PR TITLE
added support for objects to R.filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "devDependencies": {
     "ramda": "0.21.0",
-    "typescript": "^1.8.10"
+    "typescript": "^2.0.9"
   }
 }

--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -10,6 +10,19 @@ var shout = function(x: number): string {
         : 'small'
 };
 
+/** ramda independent way to check type information is not lost
+ *  for lists */
+var onlyNumberList = function(xs: number[]): number[] {
+  return xs;
+}
+
+/** ramda independent way to check type information is not lost
+ *  for simple objects */
+var onlyNumberObj = function(xs: {[key:string]: number}): {[key:string]: number} {
+  return xs;
+}
+
+
 class F {
     x = 'X';
     y = 'Y';
@@ -452,9 +465,17 @@ R.times(i, 5);
     var isEven = function(n: number) {
         return n % 2 === 0;
     };
+    // filter works with lists...
     R.filter(isEven, [1, 2, 3, 4]); //=> [2, 4]
     var isEvenFn = R.filter(isEven);
     isEvenFn([1, 2, 3, 4]);
+    // ... but also objects
+    R.filter(isEven, {a:1, b:2, c:3, d:4}); //=> {b:2, d:4}
+    isEvenFn({a:1, b:2, c:3, d:4});
+    // see that we did not break anything
+    // and we kept type information
+    onlyNumberList(R.filter(isEven,[1,2,3,4]));
+    onlyNumberObj(R.filter(isEven,{a:1, b:2, c:3, d:4}));
 }
 
 () => {
@@ -475,7 +496,7 @@ R.times(i, 5);
 }
 
 () => {
-    
+
     type Task = {id: number}
     let tasks: Task[] = []
     const a = R.find(task => task.id === 1, tasks) // this works

--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -471,7 +471,7 @@ R.times(i, 5);
     isEvenFn([1, 2, 3, 4]);
     // ... but also objects
     R.filter(isEven, {a:1, b:2, c:3, d:4}); //=> {b:2, d:4}
-    isEvenFn({a:1, b:2, c:3, d:4});
+    var isEvenFnObj = R.filter(isEven);
     // see that we did not break anything
     // and we kept type information
     onlyNumberList(R.filter(isEven,[1,2,3,4]));

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -531,10 +531,10 @@ declare namespace R {
          * Returns a new list containing only those items that match a given predicate function. The predicate function is passed one argument: (value).
          */
 
-        filter<T,U>(fn: (value: T) => boolean): (obj: U) => U;
-        filter<T,U>(fn: (value: T) => boolean, obj: U) : U;
         filter<T>(fn: (value: T) => boolean): <T>(list: T[]) => T[];
         filter<T>(fn: (value: T) => boolean, list: T[]): T[];
+        filter<T,U>(fn: (value: T) => boolean): (obj: U) => U;
+        filter<T,U>(fn: (value: T) => boolean, obj: U) : U;
 
         /**
          * Returns the first element of the list which matches the predicate, or `undefined` if no

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -530,6 +530,9 @@ declare namespace R {
         /**
          * Returns a new list containing only those items that match a given predicate function. The predicate function is passed one argument: (value).
          */
+
+        filter<T,U>(fn: (value: T) => boolean): (obj: U) => U;
+        filter<T,U>(fn: (value: T) => boolean, obj: U) : U;
         filter<T>(fn: (value: T) => boolean): <T>(list: T[]) => T[];
         filter<T>(fn: (value: T) => boolean, list: T[]): T[];
 


### PR DESCRIPTION
Hello,

`R.filter` also supports objects as their second parameter.
Added definitions and tests, including two 'general' functions to do basic type assertion.
If you prefer them to be just on this test definition, let me know, but I'm pretty sure they will be useful elsewhere.