### PR TITLE
Fix 'invoker' arity parameter position

### DIFF
--- a/ramda-tests.ts
+++ b/ramda-tests.ts
@@ -162,8 +162,8 @@ class F2 {
 }
 
 () => {
-    R.invoker('charAt', String.prototype);
-    R.invoker('charAt', String.prototype, 1);
+    R.invoker(0, 'charAt', String.prototype);
+    R.invoker(1, 'charAt', String.prototype, 1);
 }
 
 (() => {
@@ -475,7 +475,7 @@ R.times(i, 5);
 }
 
 () => {
-    
+
     type Task = {id: number}
     let tasks: Task[] = []
     const a = R.find(task => task.id === 1, tasks) // this works

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -770,8 +770,8 @@ declare namespace R {
         invoker<T, P1, P2, P3, P4, R>(len: number /* = 4 */, name:string, x1: P1, x2: P2, x3: P3, x4: P4, obj: T): R
         invoker<T, P1, P2, P3, P4, R>(len: number /* = 4 */, name:string): CurriedFunction5<P1, P2, P3, P4, T, R>
 
-        invoker<T, P1, P2, P3, P4, P5, R>(len: number /* = 4 */, name:string, x1: P1, x2: P2, x3: P3, x4: P4, x5: P5, obj: T): R
-        invoker<T, P1, P2, P3, P4, P5, R>(len: number /* = 4 */, name:string): CurriedFunction6<P1, P2, P3, P4, P5, T, R>
+        invoker<T, P1, P2, P3, P4, P5, R>(len: number /* = 5 */, name:string, x1: P1, x2: P2, x3: P3, x4: P4, x5: P5, obj: T): R
+        invoker<T, P1, P2, P3, P4, P5, R>(len: number /* = 5 */, name:string): CurriedFunction6<P1, P2, P3, P4, P5, T, R>
 
 
         /**

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -755,8 +755,24 @@ declare namespace R {
          * The returned function is curried and accepts `len + 1` parameters (or `method.length + 1`
          * when `len` is not specified), and the final parameter is the target object.
          */
-        invoker(name: string, obj: any, len?: number): Function;
-        invoker(name: string): (obj: any, len?: number) => Function;
+        invoker<T, R> (len: number /* = 0 */, name: string, obj: T): R
+        invoker<T, R> (len: number/* = 0 */, name: string): (obj: T) => R
+
+        invoker<T, P1, R>(len: number /* = 1 */, name:string, x1: P1, obj: T): R
+        invoker<T, P1, R>(len: number /* = 1 */, name:string): CurriedFunction2<P1, T, R>
+
+        invoker<T, P1, P2, R>(len: number /* = 2 */, name:string, x1: P1, x2: P2, obj: T): R
+        invoker<T, P1, P2, R>(len: number /* = 2 */, name:string): CurriedFunction3<P1, P2, T, R>
+
+        invoker<T, P1, P2, P3, R>(len: number /* = 3 */, name:string, x1: P1, x2: P2, x3: P3, obj: T): R
+        invoker<T, P1, P2, P3, R>(len: number /* = 3 */, name:string): CurriedFunction4<P1, P2, P3, T, R>
+
+        invoker<T, P1, P2, P3, P4, R>(len: number /* = 4 */, name:string, x1: P1, x2: P2, x3: P3, x4: P4, obj: T): R
+        invoker<T, P1, P2, P3, P4, R>(len: number /* = 4 */, name:string): CurriedFunction5<P1, P2, P3, P4, T, R>
+
+        invoker<T, P1, P2, P3, P4, P5, R>(len: number /* = 4 */, name:string, x1: P1, x2: P2, x3: P3, x4: P4, x5: P5, obj: T): R
+        invoker<T, P1, P2, P3, P4, P5, R>(len: number /* = 4 */, name:string): CurriedFunction6<P1, P2, P3, P4, P5, T, R>
+
 
         /**
          * See if an object (`val`) is an instance of the supplied constructor.

--- a/ramda.d.ts
+++ b/ramda.d.ts
@@ -1372,6 +1372,8 @@ declare namespace R {
          */
         reject<T>(fn: (value: T) => boolean, list: T[]): T[];
         reject<T>(fn: (value: T) => boolean): (list: T[]) => T[];
+        reject<T,U>(fn: (value: T) => boolean): (obj: U) => U;
+        reject<T,U>(fn: (value: T) => boolean, obj: U) : U;
 
         /**
          * Removes the sub-list of `list` starting at index `start` and containing `count` elements.


### PR DESCRIPTION
R.invoker signature take the first parameter as a arity: Number -> String -> (a -> b -> ... -> n -> Object -> *)

However, @types/ramda signature take the first parameter as the function name.

[https://github.com/donnut/typescript-ramda/issues/102](url)