### PR TITLE
split every works with strings

### DIFF
--- a/global/ramda.d.ts
+++ b/global/ramda.d.ts
@@ -1412,8 +1412,8 @@ declare namespace R {
         /**
          * Splits a collection into slices of the specified length.
          */
-        splitEvery<T>(a: number, list: T[]): T[][];
-        splitEvery(a: number): <T>(list: T[]) => T[][];
+        splitEvery<T>(a: number, list: T[] | string): T[][];
+        splitEvery(a: number): <T>(list: T[] | string) => T[][];
 
 
 		/**


### PR DESCRIPTION
splitEvery accepts string (as an array of character) and not only arrays